### PR TITLE
Update __init__.py

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -894,7 +894,8 @@ class datetime(date):
                 result_date['day'],
                 result_date['hour'],
                 result_date['minute'],
-                result_date['second'])
+                result_date['second'],
+                result_date['microsecond'])
         except:
             raise ValueError(
                 "time data '%s' does not match format '%s'" %


### PR DESCRIPTION
 result_date['microsecond']
"microseconds" on strptime return values (result_date['microsecond']) was missing, added.